### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 - name: Gather OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+    - "{{ ansible_facts.distribution }}.yml"
+    - "{{ ansible_facts.os_family }}.yml"
   tags: vars
 
 - name: Ensure EPEL repo is installed
@@ -15,8 +15,8 @@
   become: True
   when:
     - os_openstacksdk_install_epel | bool
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version | int == 7
+    - ansible_facts.os_family == "RedHat"
+    - ansible_facts.distribution_major_version | int == 7
 
 - name: Ensure required packages are installed
   package:
@@ -38,8 +38,8 @@
       file:
         path: "{{ os_openstacksdk_venv | dirname }}"
         state: directory
-        owner: "{{ ansible_user_uid }}"
-        group: "{{ ansible_user_gid }}"
+        owner: "{{ ansible_facts.user_uid }}"
+        group: "{{ ansible_facts.user_gid }}"
       become: True
       when:
         - not os_openstacksdk_venv_stat.stat.exists or
@@ -51,7 +51,7 @@
     name: "{{ item.name }}"
     state: latest
     virtualenv: "{{ os_openstacksdk_venv or omit }}"
-    virtualenv_python: "{{ 'python' ~ ansible_python.version.major ~ '.' ~ ansible_python.version.minor if os_openstacksdk_venv else omit }}"
+    virtualenv_python: "{{ 'python' ~ ansible_facts.python.version.major ~ '.' ~ ansible_facts.python.version.minor if os_openstacksdk_venv else omit }}"
   with_items:
     - { name: pip }
     - { name: setuptools }

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,6 @@ os_openstacksdk_package_dependencies:
   - gcc
   - libffi-dev
   - libssl-dev
-  - python{% if ansible_python.version.major == 3 %}3{% endif %}-dev
-  - python{% if ansible_python.version.major == 3 %}3{% endif %}-pip
-  - python{% if ansible_python.version.major == 3 %}3{% endif %}-virtualenv
+  - python{% if ansible_facts.python.version.major == 3 %}3{% endif %}-dev
+  - python{% if ansible_facts.python.version.major == 3 %}3{% endif %}-pip
+  - python{% if ansible_facts.python.version.major == 3 %}3{% endif %}-virtualenv

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,6 +4,6 @@ os_openstacksdk_package_dependencies:
   - gcc
   - libffi-devel
   - openssl-devel
-  - python{{ ansible_python.version.major }}-devel
-  - python{{ ansible_python.version.major }}-pip
-  - python{{ ansible_python.version.major }}-virtualenv
+  - python{{ ansible_facts.python.version.major }}-devel
+  - python{{ ansible_facts.python.version.major }}-pip
+  - python{{ ansible_facts.python.version.major }}-virtualenv


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the ansible_facts
dictionary. This allows users to disable fact variable injection in
their Ansible configuration, which may provide some performance
improvement.