### PR TITLE
Add rocky support

### DIFF
--- a/vars/Rocky.yml
+++ b/vars/Rocky.yml
@@ -1,0 +1,8 @@
+---
+# List of package dependencies.
+os_openstacksdk_package_dependencies:
+  - gcc
+  - libffi-devel
+  - openssl-devel
+  - python{{ ansible_facts.python.version.major }}-devel
+  - python{{ ansible_facts.python.version.major }}-pip


### PR DESCRIPTION
Rocky hosts currently fail [here](https://github.com/stackhpc/ansible-role-os-openstacksdk/blob/cdd2a0f59ed2871460c53368067ca705a9d04369/tasks/main.yml#L3) as their os family and distribution is Rocky, not RedHat. 

This could also be resolved by changing the templating to be something like `{{ RedHat if family is Rocky else family }}`, but giving it a different file lets us change things separately if we need to.