### PR TITLE
Update apt cache before installing dependencies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,12 @@
     - ansible_facts.os_family == "RedHat"
     - ansible_facts.distribution_major_version | int == 7
 
+- name: Ensure apt cache is up to date (Debian)
+  apt:
+    update_cache: True
+  become: True
+  when: ansible_facts.os_family == "Debian"
+
 - name: Ensure required packages are installed
   package:
     name: "{{ os_openstacksdk_package_dependencies }}"


### PR DESCRIPTION
For some reason I hit this today when setting up a Multinode. Never had a problem with it before